### PR TITLE
prasun:increasing max age of session cookie serializer to 2 days

### DIFF
--- a/egov/egov-egi/src/main/java/org/egov/infra/config/session/RedisHttpSessionConfiguration.java
+++ b/egov/egov-egi/src/main/java/org/egov/infra/config/session/RedisHttpSessionConfiguration.java
@@ -68,6 +68,7 @@ public class RedisHttpSessionConfiguration {
     @Bean
     public CookieSerializer cookieSerializer() {
         DefaultCookieSerializer serializer = new DefaultCookieSerializer();
+        serializer.setCookieMaxAge(172800);//setting to 2 days for poc demo
         serializer.setCookieName(SESSION_COOKIE_NAME);
         serializer.setCookiePath(SESSION_COOKIE_PATH);
         return serializer;


### PR DESCRIPTION
prasun:increasing max age of session cookie serializer to 2 days